### PR TITLE
Optimize deep cfr performance

### DIFF
--- a/src/core/deep_cfr.py
+++ b/src/core/deep_cfr.py
@@ -348,9 +348,10 @@ class DeepCFRAgent:
         if int(state.stage) >= 2:  # Turn or River
             adjustment *= 1.2  # Increase bets in later streets
         
-        # Adjust based on pot size relative to starting stack
-        initial_stake = state.players_state[0].stake + state.players_state[0].bet_chips
-        pot_ratio = state.pot / initial_stake
+        # Adjust based on pot size relative to original starting stake
+        # Use fixed starting stake to avoid inconsistent behavior as player stacks change
+        starting_stake = 200.0  # Original starting stake for all players
+        pot_ratio = state.pot / starting_stake
         if pot_ratio > 0.5:  # Large pot
             adjustment *= 1.1  # Bet bigger in large pots
         elif pot_ratio < 0.1:  # Small pot

--- a/src/core/model.py
+++ b/src/core/model.py
@@ -91,12 +91,13 @@ def encode_state(state, player_id=0):
     stage_enc[int(state.stage)] = 1
     encoded.append(stage_enc)
     
-    # Get initial stake - prevent division by zero
-    initial_stake = state.players_state[0].stake
-    if initial_stake <= 0:
-        if VERBOSE:
-            print(f"WARNING: Initial stake is zero or negative: {initial_stake}")
-        initial_stake = 1.0  # Use 1.0 as a fallback to prevent division by zero
+    # Use the game's starting stake for consistent normalization
+    # All players start with 200.0 in training, so use that for normalization
+    initial_stake = 200.0  # Fixed starting stake used in training
+    
+    # Alternative approach: use max stake among players (closest to starting amount)
+    # max_stake = max(p.stake for p in state.players_state) 
+    # initial_stake = max(max_stake, 1.0)  # Fallback to prevent division by zero
     
     # Encode pot size (normalized by initial stake)
     pot_enc = [state.pot / initial_stake]

--- a/src/core/model.py
+++ b/src/core/model.py
@@ -91,13 +91,10 @@ def encode_state(state, player_id=0):
     stage_enc[int(state.stage)] = 1
     encoded.append(stage_enc)
     
-    # Use the game's starting stake for consistent normalization
-    # All players start with 200.0 in training, so use that for normalization
-    initial_stake = 200.0  # Fixed starting stake used in training
-    
-    # Alternative approach: use max stake among players (closest to starting amount)
-    # max_stake = max(p.stake for p in state.players_state) 
-    # initial_stake = max(max_stake, 1.0)  # Fallback to prevent division by zero
+    # CRITICAL: Always use the original starting stake for consistent normalization
+    # This prevents encoding from breaking when players win/lose big amounts
+    # A 400-chip pot should ALWAYS encode the same way, regardless of player stacks
+    initial_stake = 200.0  # The fixed starting stake used throughout training
     
     # Encode pot size (normalized by initial stake)
     pot_enc = [state.pot / initial_stake]

--- a/src/core/optimized_model.py
+++ b/src/core/optimized_model.py
@@ -72,8 +72,8 @@ def encode_state_optimized(state: Any, player_id: int = 0) -> np.ndarray:
     num_players = len(state.players_state)
     _initialize_encoding_cache(num_players)
     
-    # Pre-calculate commonly used values
-    initial_stake = max(1.0, state.players_state[0].stake)  # Avoid division by zero
+    # Use consistent starting stake for normalization (not player's current stake)
+    initial_stake = 200.0  # Fixed starting stake used in training
     pot_size = state.pot
     min_bet = state.min_bet
     

--- a/src/core/optimized_model.py
+++ b/src/core/optimized_model.py
@@ -72,8 +72,10 @@ def encode_state_optimized(state: Any, player_id: int = 0) -> np.ndarray:
     num_players = len(state.players_state)
     _initialize_encoding_cache(num_players)
     
-    # Use consistent starting stake for normalization (not player's current stake)
-    initial_stake = 200.0  # Fixed starting stake used in training
+    # CRITICAL: Always use original starting stake for consistent normalization
+    # This prevents encoding catastrophe when players win/lose big amounts
+    # Same values should ALWAYS encode the same way regardless of player stacks
+    initial_stake = 200.0  # The fixed starting stake used throughout training
     pot_size = state.pot
     min_bet = state.min_bet
     

--- a/src/training/train_optimized.py
+++ b/src/training/train_optimized.py
@@ -54,7 +54,7 @@ def evaluate_against_random(agent, num_games=500, num_players=6):
                 sb=1,
                 bb=2,
                 stake=200.0,
-                seed=game
+                seed=random.randint(0, 2147483647)  # Random evaluation games
             )
             
             # Play until the game is over
@@ -162,7 +162,7 @@ def train_deep_cfr(num_iterations=100, traversals_per_iteration=50,
                 sb=1,
                 bb=2,
                 stake=200.0,
-                seed=random.randint(0, 10000)
+                seed=random.randint(0, 2147483647)  # Full 32-bit range for maximum variety
             )
             
             # Perform CFR traversal


### PR DESCRIPTION
Fix critical learning bugs by expanding game seed variety and ensuring consistent state normalization.

The previous implementation limited game seeds to 10,001 unique games, causing the agent to repeatedly encounter the same scenarios and preventing true strategic learning. Additionally, state normalization for pot and bet sizes incorrectly used a player's current dynamic stake instead of a fixed starting stake, leading to wildly inconsistent encodings for identical game situations and hindering the neural network's ability to learn. These fixes are crucial for the agent to learn effectively.

---
<a href="https://cursor.com/background-agent%3FbcId=bc-768b6835-18dc-4c0a-b820-3927333fd165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents%3Fid=bc-768b6835-18dc-4c0a-b820-3927333fd165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>